### PR TITLE
Replace 'ISS' by generic 'satellite'

### DIFF
--- a/Solvers/Earth-Satellite-Passes.ipynb
+++ b/Solvers/Earth-Satellite-Passes.ipynb
@@ -118,13 +118,13 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "The above graph makes perfect sense. A satellite orbit can be thought of as an ellipse that hangs stable in space while the Earth rotates beneath it. In this graph, we can see that for part of the day Boston is quite distant from the (rough) great circle that the ISS travels above the planet\u2019s surface, so through those hours the ISS stays well below the horizon. But then Boston rotates around and beneath the arc of the orbit, so during those hours the ISS passes repeatedly overhead and its altitude goes briefly positive.\n",
+      "The above graph makes perfect sense. A satellite orbit can be thought of as an ellipse that hangs stable in space while the Earth rotates beneath it. In this graph, we can see that for part of the day Boston is quite distant from the (rough) great circle that the satellite travels above the planet\u2019s surface, so through those hours the satellite stays well below the horizon. But then Boston rotates around and beneath the arc of the orbit, so during those hours the satellite passes repeatedly overhead and its altitude goes briefly positive.\n",
       "\n",
-      "What we would like to do is locate each point where the ISS reaches a maximum altitude \u2014 but to do so quickly, without taking the full 15 seconds that my laptop required to produce the every-minute-of-the-day graph above.\n",
+      "What we would like to do is locate each point where the satellite reaches a maximum altitude \u2014 but to do so quickly, without taking the full 15 seconds that my laptop required to produce the every-minute-of-the-day graph above.\n",
       "\n",
-      "How much resolution do we need \u2014 how many points per orbit \u2014 to be able to identify at least one point that is over on Boston\u2019s side of the Earth and where we could start a search? If for each orbit of the ISS we ask for six points, then they should form a rough hexagon in space around the Earth \u2014 and one of those points should have a clearly higher altitude than its neighbors, and thus draw our attention to the part of the orbit we need more information about.\n",
+      "How much resolution do we need \u2014 how many points per orbit \u2014 to be able to identify at least one point that is over on Boston\u2019s side of the Earth and where we could start a search? If for each orbit of the satellite we ask for six points, then they should form a rough hexagon in space around the Earth \u2014 and one of those points should have a clearly higher altitude than its neighbors, and thus draw our attention to the part of the orbit we need more information about.\n",
       "\n",
-      "That is, a six-points-per-revolution sampling of the ISS position should preserve enough of the shape of the above graph that we can see each of the maxima \u2014 even though we will no longer yet know exactly how high it was.\n",
+      "That is, a six-points-per-revolution sampling of the satellite position should preserve enough of the shape of the above graph that we can see each of the maxima \u2014 even though we will no longer yet know exactly how high it was.\n",
       "\n",
       "To learn this we need to look at the orbital element that tells us how fast the satellite moves. I should think about adding a better name for it to Skyfield:"
      ]
@@ -156,7 +156,7 @@
      "source": [
       "This agrees fairly well with the same number as stated in sources like the Wikipedia, so we appear to have computed it correctly!\n",
       "\n",
-      "We can now ask for the ISS position over a whole day, but with only six points per complete orbit, and the graph should come back quite quickly:"
+      "We can now ask for the satellite position over a whole day, but with only six points per complete orbit, and the graph should come back quite quickly:"
      ]
     },
     {
@@ -197,7 +197,7 @@
      "source": [
       "That was much quicker!\n",
       "\n",
-      "And from the shape of the graph, it looks like we were right. With only six points per orbit we are unlikly to happen to find the exact moments where the ISS is highest \u2014 but we have at least identified the rough time of each peak and can start searching there!\n",
+      "And from the shape of the graph, it looks like we were right. With only six points per orbit we are unlikly to happen to find the exact moments where the satellite is highest \u2014 but we have at least identified the rough time of each peak and can start searching there!\n",
       "\n",
       "Let us use the magic of NumPy to ask for the peaks. They are the places where the altitude stops getting bigger and starts getting smaller:"
      ]
@@ -260,7 +260,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "With this function in hand, we can set one of the standard SciPy solvers to work on finding the minimum that lies close to each of the green dots in the above plot \u2014 each of which should be a maximum altitude reached by the ISS during one of its passes overhead (if the resulting value is greater than zero, of course)."
+      "With this function in hand, we can set one of the standard SciPy solvers to work on finding the minimum that lies close to each of the green dots in the above plot \u2014 each of which should be a maximum altitude reached by the satellite during one of its passes overhead (if the resulting value is greater than zero, of course)."
      ]
     },
     {


### PR DESCRIPTION
The notebook is generic, and the example TLE is actually for Tiangong
1, not ISS. Thus the text should not refer to ISS, but to the generic
term ‘satellite’